### PR TITLE
services hash to yaml generate garbage

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -46,7 +46,7 @@ def generate_config
   services = {
     '#services' => new_resource.services
   }
-  services_yml = services.to_yaml(:indentation => 2).gsub(/(! )?['"]#services['"]:/, '#services:').gsub('---', '').gsub(%r{!(ruby\/|map|seq)[a-zA-Z:]*}, '')
+  services_yml = JSON.parse(services.to_hash.dup.to_json).to_yaml(:indentation => 2).gsub(/(! )?['"]#services['"]:/, '#services:').gsub('---', '').gsub(%r{!(ruby\/|map|seq)[a-zA-Z:]*}, '')
 
   # service restart
   service 'restart-newrelic-plugin-agent' do


### PR DESCRIPTION
to_yaml has generated garbage and make the newrelic plugin configuration completely invalid.  The fix is to convert Chef's Hash to ruby hash , then JSON then to yaml.  Without the JSON part still causing garbage in the configuration.

This problem seems happened with Chef 12.  Here is a similar case with the to_yaml. (http://lists.opscode.com/sympa/arc/chef/2014-02/msg00054.html)